### PR TITLE
REP-3680 LMT: Enhance top header functionality 

### DIFF
--- a/app/assets/stylesheets/tolk/screen.css
+++ b/app/assets/stylesheets/tolk/screen.css
@@ -137,7 +137,7 @@ h2,
 h3 {
   font-size: 18px;
   color: #2fadcf;
-  margin: 25px 0 10px;
+  margin: 7px 0 13px;
 }
 
 h2 span,

--- a/app/assets/stylesheets/tolk/screen.css
+++ b/app/assets/stylesheets/tolk/screen.css
@@ -221,9 +221,13 @@ span.updated {
 
 div.table_submit {
   background: #f5f5f5;
-  margin: -25px 0 0;
   padding: 12px 15px 15px;
   text-align: left;
+}
+
+div.table_submit > p {
+  width: 49%;
+  display: inline-block;
 }
 
 div.table_submit input.save {
@@ -378,9 +382,12 @@ Pagination
 -------------------------------------------------*/
 
 div.paginate {
-  margin: 15px auto 20px;
   font-size: 12px;
   color: #777;
+  text-align: right;
+  width: 49%;
+  display: inline-block;
+  line-height: 8px;
 }
 
 div.paginate .center-block {
@@ -390,6 +397,11 @@ div.paginate .center-block {
 
 div.paginate ul li {
   float: left;
+}
+
+div.paginate ul li.active a {
+  font-weight: 800;
+  color: black;
 }
 
 div.paginate a,
@@ -427,6 +439,12 @@ div.paginate .disabled {
   margin-top: 5px;
 }
 
+.categories-selector:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
 .categories-title {
   padding: 14px;
   margin: 11px 0;
@@ -450,7 +468,8 @@ div.paginate .disabled {
   color: black;
 }
 
-.category > a:hover {
+.category > a:hover,
+.category > a.active {
   color: white;
 }
 
@@ -459,4 +478,12 @@ div.sync-action {
   position: absolute;
   right: 25px;
   bottom: 15px;
+}
+
+.search {
+  margin-bottom: 12px;
+}
+
+.warning-notice {
+  color: red;
 }

--- a/app/controllers/tolk/locales_controller.rb
+++ b/app/controllers/tolk/locales_controller.rb
@@ -36,7 +36,15 @@ module Tolk
     end
 
     def all
-      @phrases = @locale.phrases_with_translation(params[pagination_param])
+      @phrases = Tolk::Phrase.where(category: params[:category])
+        .preload(:translations)
+        .order(:key)
+        .public_send(pagination_method, params[pagination_param])
+      translations = Tolk::Translation.where(locale: @locale, phrase_id: @phrases.select(:id))
+      @phrases.each do |p|
+        p.translation = translations.find { |t| t.phrase_id == p.id }
+      end
+      render :show
     end
 
     def updated

--- a/app/controllers/tolk/locales_controller.rb
+++ b/app/controllers/tolk/locales_controller.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
 module Tolk
   class LocalesController < Tolk::ApplicationController
     before_action :find_locale, only: [:show, :all, :update, :updated]
     before_action :ensure_no_primary_locale, only: [:all, :update, :show, :updated]
+
+    helper_method :category_known?
 
     def index
       # HACK: allows to select primary locale
@@ -12,8 +15,9 @@ module Tolk
     def show
       respond_to do |format|
         format.html do
-          @phrases = @locale.phrases_without_translation(params[pagination_param]).order(:key)
-          @phrases = @phrases.where(category: params[:category]) if params[:category]
+          @phrases = @locale.phrases_without_translation(params[pagination_param])
+            .where(category: params[:category])
+            .order(:key)
         end
 
         format.atom { @phrases = @locale.phrases_without_translation(params[pagination_param]).order(:key).per(50) }
@@ -77,7 +81,7 @@ module Tolk
     private
 
     def find_locale
-      @locale = Tolk::Locale.where('UPPER(name) = UPPER(?)', params[:id]).first!
+      @locale = Tolk::Locale.where("UPPER(name) = UPPER(?)", params[:id]).first!
     end
 
     def locale_params
@@ -88,5 +92,8 @@ module Tolk
       params.permit(translations: [:id, :phrase_id, :locale_id, :text])[:translations]
     end
 
+    def category_known?
+      params[:category].present?
+    end
   end
 end

--- a/app/controllers/tolk/searches_controller.rb
+++ b/app/controllers/tolk/searches_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Tolk
   class SearchesController < Tolk::ApplicationController
     before_action :find_locale
@@ -6,13 +7,14 @@ module Tolk
       @phrases = @locale.search_phrases(params[:q],
                                         params[:scope].to_sym,
                                         params[:k],
-                                        params[pagination_param])
+                                        params[pagination_param],
+                                        params[:category])
     end
 
     private
 
     def find_locale
-      @locale = Tolk::Locale.where('UPPER(name) = UPPER(?)', params[:tolk_locale]).first!
+      @locale = Tolk::Locale.where("UPPER(name) = UPPER(?)", params[:tolk_locale]).first!
     end
   end
 end

--- a/app/models/tolk/phrase.rb
+++ b/app/models/tolk/phrase.rb
@@ -12,11 +12,11 @@ module Tolk
 
     has_many :translations, class_name: "Tolk::Translation", dependent: :destroy do
       def primary
-        to_a.detect {|t| t.locale_id == Tolk::Locale.primary_locale.id}
+        to_a.detect { |t| t.locale_id == Tolk::Locale.primary_locale.id }
       end
 
       def for(locale)
-        to_a.detect {|t| t.locale_id == locale.id}
+        to_a.detect { |t| t.locale_id == locale.id }
       end
     end
 

--- a/app/models/tolk/phrase.rb
+++ b/app/models/tolk/phrase.rb
@@ -23,10 +23,10 @@ module Tolk
     attr_accessor :translation
 
     scope :containing_text, ->(q) { q.presence && where(Tolk::Phrase.arel_table[:key].matches("%#{q}%")) }
-    scope :with_category, ->(cat) { cat.presence && where(category_field.eq(cat)) }
+    scope :with_category, ->(cat) { where(category: cat) }
 
     def self.categories
-      Tolk::Phrase.select(:category).distinct.pluck(:category)
+      Tolk::Phrase.select(:category).order(:category).distinct.pluck(:category)
     end
   end
 end

--- a/app/views/tolk/locales/_categories.html.erb
+++ b/app/views/tolk/locales/_categories.html.erb
@@ -5,9 +5,8 @@
   <ul class="categories">
     <% Tolk::Phrase::categories.each do |category| %>
       <li class="category">
-        <%= link_to category, locale_path(locale, category: category) %>
+        <%= link_to(category, locale_path(locale, category: category), class: current_category == category ? "active" : "") %>
       </li>
     <% end %>
   </ul>
 </div>
-

--- a/app/views/tolk/locales/_phrases_submit_panel.html.erb
+++ b/app/views/tolk/locales/_phrases_submit_panel.html.erb
@@ -1,0 +1,11 @@
+<div class="table_submit">
+  <p>
+    <%= form.submit "Save changes", class: "save" %>
+    <span class="warning-notice">Please make sure your work is saved very 15 minutes!</span>
+  </p>
+  <div class="paginate">
+    <div class="center-block">
+      <%= tolk_paginate phrases %>
+    </div>
+  </div>
+</div>

--- a/app/views/tolk/locales/all.html.erb
+++ b/app/views/tolk/locales/all.html.erb
@@ -4,22 +4,19 @@
   <span class="notice">Some phrases have changed. <%= link_to "Update translations", updated_locale_path(@locale) %>.</span>
 <% end %>
 
+<%= render partial: "tolk/locales/categories", locals: { locale: @locale, current_category: params[:category] } %>
+
 <div class="search">
   <%= render partial: "tolk/searches/form", locals: { locale: @locale } %>
-</div>
-
-<div class="categories-selector">
-  <ul class="categories">
-    <% @phrases.map(&:category).uniq.each do |category| %>
-      <li class="category"><a href="#<%= category.parameterize %>"><%= category.titleize %></a></li>
-    <% end %>
-  </ul>
 </div>
 
 <div class="translations">
 <% if @phrases.any? %>
   <%= form_for @locale do |locale_form| %>
-        <table class="translations">
+
+    <%= render partial: "tolk/locales/phrases_submit_panel", locals: { form: locale_form, phrases: @phrases } %>
+
+    <table class="translations">
       <tr>
         <th class="translation"><%= @locale.language_name -%></th>
         <th class="actions"></th>
@@ -63,14 +60,9 @@
         <% end %>
       <% end %>
     </table>
-    <div class="table_submit">
-      <p><%= locale_form.submit "Save changes", class: 'save' %></p>
-    </div>
-    <div class="paginate">
-      <div class="center-block">
-        <%= tolk_paginate @phrases %>
-      </div>
-    </div>
+
+    <%= render partial: "tolk/locales/phrases_submit_panel", locals: { form: locale_form, phrases: @phrases } %>
+
   <% end %>
 <% else %>
   <p style="text-align: left">There aren't any completed translations for this locale.</p>

--- a/app/views/tolk/locales/show.html.erb
+++ b/app/views/tolk/locales/show.html.erb
@@ -2,66 +2,66 @@
   <link rel="alternate" type="application/rss+xml" title="RSS" href="<%= locale_path(@locale, format: 'atom') -%>" />
 <% end %>
 
-<h3 class="switch">Phrases missing translation (<%= @locale.count_phrases_without_translation %>) <span>(<%= link_to "See completed translations", all_locale_path(@locale) %>)</span></h3>
-
 <% if @locale.has_updated_translations? && action_name != "updated" %>
   <span class="notice">Some phrases have changed. <%= link_to "Update translations", updated_locale_path(@locale) %>.</span>
 <% end %>
 
-<div class="search">
-  <%= render partial: "tolk/searches/form", locals: { locale: @locale } %>
-</div>
+<%= render partial: "tolk/locales/categories", locals: { locale: @locale, current_category: params[:category] } %>
 
-<%= render partial: "tolk/locales/categories", locals: { locale: @locale } %>
+<% if category_known? %>
+  <div class="search">
+    <%= render partial: "tolk/searches/form", locals: { locale: @locale } %>
+  </div>
 
-<div class="translations">
-  <% if @phrases.any? %>
-     <%= form_for @locale do |locale_form| %>
-      <table class="translations">
-        <tr>
-          <th class="translation"><%= @locale.language_name -%></th>
-          <th class="actions"></th>
-          <th class="key"><%= Tolk::Locale.primary_language_name -%></th>
-        </tr>
-        <% @phrases.each do |phrase| %>
+  <div class="translations">
+    <% if @phrases.any? %>
+      <%= form_for @locale do |locale_form| %>
+
+        <%= render partial: "tolk/locales/phrases_submit_panel", locals: { form: locale_form, phrases: @phrases } %>
+
+        <table class="translations">
           <tr>
-            <% translation = Tolk::Translation.new(locale: @locale, phrase: phrase) %>
-            <td class="translation">
-              <%= hidden_field_tag :"translations[][id]", translation.id, id: "#{translation.object_id}_id" %>
-              <%= hidden_field_tag :"translations[][phrase_id]", phrase.id, id: "#{translation.object_id}_phrase_id" %>
-              <%= hidden_field_tag :"translations[][locale_id]", translation.locale_id, id: "#{translation.object_id}_locale_id" %>
-              <%= text_area_tag :"translations[][text]", format_i18n_text_area_value(translation.text), class: "locale", id: "#{translation.object_id}_text" %>
-            </td>
-            <td class="actions">
-              <a class="copy" href="#" tabindex="-1" title="Copy original translation">&larr;</a><br>
-              <span class="warning" title="Interpolation keys don't match">⚠</span>
-            </td>
-            <td class="original">
-              <a name="<%= phrase.category.parameterize %>"></a>
-              <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.try(:text)), disabled: true %>
-
-              <% if params[:q].present? -%>
-                <%= highlight(format_i18n_value(phrase.translations.primary.try(:text)), params[:q]) -%>
-              <% else -%>
-                <%= format_i18n_value(phrase.translations.primary.try(:text)) -%>
-              <% end -%>
-              <%= boolean_warning if phrase.translations.primary.try(:boolean?) -%>
-
-              <span class="key" title="<%= phrase.key %>"><%= truncate(phrase.key, length: 100) %></span>
-            </td>
+            <th class="translation"><%= @locale.language_name -%></th>
+            <th class="actions"></th>
+            <th class="key"><%= Tolk::Locale.primary_language_name -%></th>
           </tr>
-        <% end %>
-      </table>
-      <div class="table_submit">
-        <p><%= locale_form.submit "Save changes", class: "save" %></p>
-      </div>
+          <% @phrases.each do |phrase| %>
+            <tr>
+              <% translation = Tolk::Translation.new(locale: @locale, phrase: phrase) %>
+              <td class="translation">
+                <%= hidden_field_tag :"translations[][id]", translation.id, id: "#{translation.object_id}_id" %>
+                <%= hidden_field_tag :"translations[][phrase_id]", phrase.id, id: "#{translation.object_id}_phrase_id" %>
+                <%= hidden_field_tag :"translations[][locale_id]", translation.locale_id, id: "#{translation.object_id}_locale_id" %>
+                <%= text_area_tag :"translations[][text]", format_i18n_text_area_value(translation.text), class: "locale", id: "#{translation.object_id}_text" %>
+              </td>
+              <td class="actions">
+                <a class="copy" href="#" tabindex="-1" title="Copy original translation">&larr;</a><br>
+                <span class="warning" title="Interpolation keys don't match">⚠</span>
+              </td>
+              <td class="original">
+                <a name="<%= phrase.category.parameterize %>"></a>
+                <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.try(:text)), disabled: true %>
+
+                <% if params[:q].present? -%>
+                  <%= highlight(format_i18n_value(phrase.translations.primary.try(:text)), params[:q]) -%>
+                <% else -%>
+                  <%= format_i18n_value(phrase.translations.primary.try(:text)) -%>
+                <% end -%>
+                <%= boolean_warning if phrase.translations.primary.try(:boolean?) -%>
+
+                <span class="key" title="<%= phrase.key %>"><%= truncate(phrase.key, length: 100) %></span>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+
+        <%= render partial: "tolk/locales/phrases_submit_panel", locals: { form: locale_form, phrases: @phrases } %>
+
+      <% end %>
+    <% else %>
+      <p style="text-align: left">There aren't any missing or updated phrases that need translation.</p>
     <% end %>
-    <div class="paginate">
-      <div class="center-block">
-        <%= tolk_paginate @phrases %>
-      </div>
-    </div>
-  <% else %>
-    <p style="text-align: left">There aren't any missing or updated phrases that need translation.</p>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <div>Select a category...</div>
+<% end %>

--- a/app/views/tolk/locales/show.html.erb
+++ b/app/views/tolk/locales/show.html.erb
@@ -9,6 +9,11 @@
 <%= render partial: "tolk/locales/categories", locals: { locale: @locale, current_category: params[:category] } %>
 
 <% if category_known? %>
+  <h3 class="switch">
+    Phrases missing translation (<%= @locale.count_phrases_without_translation(params[:category]) %>)
+    <span>(<%= link_to "See all translations", all_locale_path(@locale, category: params[:category]) %>)</span>
+  </h3>
+
   <div class="search">
     <%= render partial: "tolk/searches/form", locals: { locale: @locale } %>
   </div>
@@ -27,7 +32,7 @@
           </tr>
           <% @phrases.each do |phrase| %>
             <tr>
-              <% translation = Tolk::Translation.new(locale: @locale, phrase: phrase) %>
+              <% translation = phrase.translation || Tolk::Translation.new(locale: @locale, phrase: phrase) %>
               <td class="translation">
                 <%= hidden_field_tag :"translations[][id]", translation.id, id: "#{translation.object_id}_id" %>
                 <%= hidden_field_tag :"translations[][phrase_id]", phrase.id, id: "#{translation.object_id}_phrase_id" %>

--- a/app/views/tolk/searches/_form.html.erb
+++ b/app/views/tolk/searches/_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_tag search_path, :method => :get do %>
   <%= hidden_field_tag :tolk_locale, locale.name %>
+  <%= hidden_field_tag :category, params[:category] %>
   Search for
   <%= scope_selector_for(@locale) %>
   phrase:

--- a/app/views/tolk/searches/show.html.erb
+++ b/app/views/tolk/searches/show.html.erb
@@ -1,18 +1,15 @@
-<h3 class="search">
-  <%= render :partial => "form", :locals => { :locale => @locale } %>
-</h3>
+<%= render partial: "tolk/locales/categories", locals: { locale: @locale, current_category: params[:category] } %>
 
-<div class="search_exits">
-  <%= link_to "Phrases missing translation", @locale %>
-  &nbsp;
-  <%= link_to "Completed translations", all_locale_path(@locale) %>
+<div class="search">
+  <%= render partial: "form", locals: { locale: @locale } %>
 </div>
-
-<%= render partial: "tolk/locales/categories", locals: { locale: @locale } %>
 
 <div class="translations">
   <% if @phrases.any? %>
      <%= form_for @locale do |locale_form| %>
+
+     <%= render partial: "tolk/locales/phrases_submit_panel", locals: { form: locale_form, phrases: @phrases } %>
+
       <table class="translations">
         <tr>
           <th class="translation"><%= @locale.language_name -%></th>
@@ -21,13 +18,13 @@
         </tr>
         <% @phrases.each do |phrase| %>
 
-          <% if translation = phrase.translations.where(locale_id: @locale.id).first || Tolk::Translation.new(:locale => @locale, :phrase => phrase) %>
+          <% if translation = phrase.translations.where(locale_id: @locale.id).first || Tolk::Translation.new(locale: @locale, phrase: phrase) %>
             <tr>
               <td class="translation">
-                <%= hidden_field_tag :"translations[][id]", translation.id, :id => "#{translation.object_id}_id" %>
-                <%= hidden_field_tag :"translations[][phrase_id]", phrase.id, :id => "#{translation.object_id}_phrase_id" %>
-                <%= hidden_field_tag :"translations[][locale_id]", translation.locale_id, :id => "#{translation.object_id}_locale_id" %>
-                <%= text_area_tag :"translations[][text]", format_i18n_text_area_value(translation.text), :class => "locale", :id => "#{translation.object_id}_text", :onfocus => "$(this).up('tr').addClassName('active');", :onblur => "$(this).up('tr').removeClassName('active');" %>
+                <%= hidden_field_tag :"translations[][id]", translation.id, id: "#{translation.object_id}_id" %>
+                <%= hidden_field_tag :"translations[][phrase_id]", phrase.id, id: "#{translation.object_id}_phrase_id" %>
+                <%= hidden_field_tag :"translations[][locale_id]", translation.locale_id, id: "#{translation.object_id}_locale_id" %>
+                <%= text_area_tag :"translations[][text]", format_i18n_text_area_value(translation.text), class: "locale", id: "#{translation.object_id}_text", onfocus: "$(this).up('tr').addClassName('active');", onblur: "$(this).up('tr').removeClassName('active');" %>
               </td>
               <td class="actions">
                 <a class="copy" href="#" tabindex="-1" title="Copy original translation">&larr;</a><br>
@@ -35,7 +32,7 @@
               </td>
               <td class="original">
                 <a name="<%= phrase.category.parameterize %>"></a>
-                <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.text), :disabled => true %>
+                <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.text), disabled: true %>
 
                 <% if params[:q].present? -%>
                   <%= highlight(format_i18n_value(phrase.translations.primary.text), params[:q]) -%>
@@ -45,20 +42,17 @@
                 <%= boolean_warning if phrase.translations.primary.boolean? -%>
 
                 <span class="key" title="<%= phrase.key %>"><%= params[:k].present? ?
-                highlight(h(truncate(phrase.key, :length => 100)), params[:k]) :
-                h(truncate(phrase.key, :length => 100)) %></span>
+                highlight(h(truncate(phrase.key, length: 100)), params[:k]) :
+                h(truncate(phrase.key, length: 100)) %></span>
               </td>
             </tr>
           <% end %>
         <% end %>
       </table>
-      <div class="table_submit">
-        <p><%= locale_form.submit "Save changes", :class => 'save' %></p>
-      </div>
+
+      <%= render partial: "tolk/locales/phrases_submit_panel", locals: { form: locale_form, phrases: @phrases } %>
+
     <% end %>
-    <div class="paginate">
-      <%= tolk_paginate @phrases %>
-    </div>
   <% else %>
     <p style="text-align: left">No search results.</p>
   <% end %>

--- a/app/views/tolk/searches/show.html.erb
+++ b/app/views/tolk/searches/show.html.erb
@@ -1,5 +1,10 @@
 <%= render partial: "tolk/locales/categories", locals: { locale: @locale, current_category: params[:category] } %>
 
+<h3 class="switch">
+  Phrases missing translation (<%= @locale.count_phrases_without_translation(params[:category]) %>)
+  <span>(<%= link_to "See all translations", all_locale_path(@locale, category: params[:category]) %>)</span>
+</h3>
+
 <div class="search">
   <%= render partial: "form", locals: { locale: @locale } %>
 </div>


### PR DESCRIPTION
[✓] application domains top header to be always present in its entire content, regardless of filtering (e.g. missing translation) and sorted in alphabetical order
[✓] application domain button to appear as selected for the working on application domain
[✓] search functionality to be below application domains top header
[✓] search functionality to be performed aginst current working on application domain
[✓] filtering by completed/uncomplicated phrases to be under search control and performed for selected application domain; selected link to be in bold
[✓] paging to be replicated under completed/uncomplicated phrases links and performed against selected application domain; selected page to be in bold
[✓] replicate "Save changes" button and functionality within "Domain" section
[✓] add help text below the "Save changes" top button to remind users to save its work

Filter by complete/incomplete translation will be in additional PR.