### PR TITLE
REP-3723 fix sync && force english locale

### DIFF
--- a/app/controllers/tolk/application_controller.rb
+++ b/app/controllers/tolk/application_controller.rb
@@ -7,6 +7,7 @@ module Tolk
 
     cattr_accessor :authenticator
     before_action :authenticate
+    before_action :force_english
 
     def authenticate
 #      self.authenticator.bind(self).call if self.authenticator && self.authenticator.respond_to?(:call)
@@ -16,6 +17,12 @@ module Tolk
     def ensure_no_primary_locale
       # HACK: would like to allow to edit primary locale
       # redirect_to locales_path if @locale.primary?
+    end
+
+    private
+
+    def force_english
+      I18n.locale = :en
     end
   end
 end

--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -94,7 +94,7 @@ module Tolk
         translations.each do |key, text|
           next unless store?(text)
 
-          phrase = Tolk::Phrase.find_or_create_by(key: key)
+          phrase = Tolk::Phrase.create_with(category: category).find_or_create_by(key: key)
           phrase.update_columns(obsolete: false, category: category)
 
           translation = Tolk::Translation.find_or_initialize_by(locale: locale, phrase: phrase)


### PR DESCRIPTION
sync_phrases was crashing because category is mandatory

A M3 ticket will follow